### PR TITLE
Allow optional cache key to take in a proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Examples:
 	json.cache_collection! @people, expires_in: 10.minutes, key: 'v1' do |person|
 	  json.partial! 'person', :person => person
 	end
+	
+	# Or with a proc as a key 
+	
+	json.cache_collection! @people, expires_in: 10.minutes, key: proc {|person| person.last_posted_at } do |person|
+      json.partial! 'person', :person => person
+    end
   
 NOTE: If the items in your collection don't change frequently, it might be better to cache the entire collection like this:
 (in which case you don't need this gem)

--- a/lib/jbuilder_cache_multi/jbuilder_ext.rb
+++ b/lib/jbuilder_cache_multi/jbuilder_ext.rb
@@ -49,6 +49,7 @@ JbuilderTemplate.class_eval do
     key = options.delete(:key)
 
     collection.inject({}) do |result, item|
+      key = key.respond_to?(:call) ? key.call(item) : key
       cache_key = key ? [key, item] : item
       result[_cache_key_fetch_multi(cache_key, options)] = item
       result

--- a/test/jbuilder_template_test.rb
+++ b/test/jbuilder_template_test.rb
@@ -17,6 +17,8 @@ BLOG_POST_PARTIAL = <<-JBUILDER
   end
 JBUILDER
 
+CACHE_KEY_PROC = Proc.new { |blog_post| true }
+
 BlogPost = Struct.new(:id, :body, :author_name)
 blog_authors = [ 'David Heinemeier Hansson', 'Pavel Pravosud' ].cycle
 BLOG_POST_COLLECTION = 10.times.map{ |i| BlogPost.new(i+1, "post body #{i+1}", blog_authors.next) }
@@ -74,6 +76,19 @@ class JbuilderTemplateTest < ActionView::TestCase
       end
     JBUILDER
         
+    assert_collection_rendered json
+  end
+
+  test 'renders cached array with a key specified as a proc' do
+    undef_context_methods :fragment_name_with_digest, :cache_fragment_name
+    CACHE_KEY_PROC.expects(:call)
+
+    json = render_jbuilder <<-JBUILDER
+      json.cache_collection! BLOG_POST_COLLECTION, key: CACHE_KEY_PROC do |blog_post|
+        json.partial! 'blog_post', :blog_post => blog_post
+      end
+    JBUILDER
+
     assert_collection_rendered json
   end
   


### PR DESCRIPTION
@joshblour 
Hey, I've amended the way optional keys are handled such that a `proc` can be passed in.

It's useful for cases whereby other attributes of an item in the collection needs to be used as a cache key, other than the default `cache_key`. In some cases it is not feasible to override the `cache_key` method of the items itself.
